### PR TITLE
Add threads argument

### DIFF
--- a/flask_gunicorn.py
+++ b/flask_gunicorn.py
@@ -22,7 +22,7 @@ def server_bind_address():
 
 
 def number_of_workers():
-    if not 'WEB_CONCURRENCY' in os.environ:
+    if 'WEB_CONCURRENCY' not in os.environ:
         return (multiprocessing.cpu_count() * 2) + 1
     else:
         return os.environ['WEB_CONCURRENCY']
@@ -74,10 +74,11 @@ class GunicornStandalone(gunicorn.app.base.BaseApplication):
 @click.option('--debugger/--no-debugger', default=None,
               help='Enable or disable the debugger.  By default the debugger '
                    'is active if debug is enabled.')
-@click.option('--workers', '-w', default=number_of_workers(), help='Number of Gunicorn workers')
-@click.option('--worker_class', '-wc', default=None, help="Specify a custom class of worker to use")
+@click.option('--workers', '-w', default=number_of_workers(), help='Number of Gunicorn workers.')
+@click.option('--worker_class', '-wc', default=None, help="Specify a custom class of worker to use.")
+@click.option('--threads', default=1, help='The number if worker threads for handling requests. [1]')
 @flask.cli.pass_script_info
-def cli(info, host, port, reload, debugger, workers, worker_class):
+def cli(info, host, port, reload, debugger, workers, threads, worker_class):
 
     os.environ['FLASK_RUN_FROM_CLI_SERVER'] = '1'
     debug = flask.cli.get_debug_flag()
@@ -86,7 +87,8 @@ def cli(info, host, port, reload, debugger, workers, worker_class):
     host = host or server_bind_address()
 
     options = {
-        'workers': workers or number_of_workers(),
+        'workers': workers,
+        'threads': threads,
         'bind': '{}:{}'.format(host, port)
     }
 


### PR DESCRIPTION
Add threads when parsing arguments, add argument to the `cli` function and add to options sent to gunicorn.
Add final dot on some help strings.
Remove unnecessary `number_of_workers()` in options since it is already been set as default in the argument parser.
Small change in `number_of_workers` to make it more Pythonic.